### PR TITLE
fix(global_services): check cache file exists before opening

### DIFF
--- a/workflow/src/global_services.py
+++ b/workflow/src/global_services.py
@@ -34,6 +34,9 @@ def write_to_cache(key: str, value: Union[str, int, float, bool]) -> None:
 def read_from_cache(entry: str) -> Union[str, int, float, bool, None]:
     """Reads the cache file and returns the value of the entry."""
 
-    with open(__cache_file_path, "rb") as plist:
-        data = plistlib.load(plist)
-    return data.get(entry)
+    if os.path.exists(__cache_file_path):
+        with open(__cache_file_path, "rb") as plist:
+            data = plistlib.load(plist)
+        return data.get(entry)
+    else:
+        return False


### PR DESCRIPTION
On a fresh install, the `ChatFred_Cache` file doesn't exist so when you run a query, the `read_from_cache` function will fail as the file doesn't exist.

```
[08:24:06.324] ChatFred[Keyword] Processing complete
[08:24:06.325] ChatFred[Keyword] Passing output 'hello' to Run Script
[08:24:06.661] ERROR: ChatFred[Run Script] Traceback (most recent call last):
  File "/Users/stephenyu/Documents/dotfiles/alfred_preferences/Alfred.alfredpreferences/workflows/user.workflow.78145D32-07AE-47DA-B3F0-F7E68D1F25AC/src/text_chat.py", line 186, in <module>
    __prompt, __response = make_chat_request(
  File "/Users/stephenyu/Documents/dotfiles/alfred_preferences/Alfred.alfredpreferences/workflows/user.workflow.78145D32-07AE-47DA-B3F0-F7E68D1F25AC/src/text_chat.py", line 147, in make_chat_request
    intercept_custom_prompts(prompt)
  File "/Users/stephenyu/Documents/dotfiles/alfred_preferences/Alfred.alfredpreferences/workflows/user.workflow.78145D32-07AE-47DA-B3F0-F7E68D1F25AC/src/text_chat.py", line 98, in intercept_custom_prompts
    last_request_successful = read_from_cache("last_chat_request_successful")
  File "/Users/stephenyu/Documents/dotfiles/alfred_preferences/Alfred.alfredpreferences/workflows/user.workflow.78145D32-07AE-47DA-B3F0-F7E68D1F25AC/src/global_services.py", line 37, in read_from_cache
    with open(__cache_file_path, "rb") as plist:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/stephenyu/Library/Application Support/Alfred/Workflow Data/ai.lemke.chatfred/ChatFred_Cache'
```

This fix checks if the file exists first