### PR TITLE
add: support for custom API paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,31 @@
 **[Alfred workflow](https://www.alfredapp.com/workflows/) using [ChatGPT](https://chat.openai.com/chat), [DALL·E 2](https://openai.com/product/dall-e-2) and other models for chatting, image generation and more.**
 
 ## Table of contents 📚
-- [Setup](#setup-)
-- [Usage](#usage-)
-    - [Talk to ChatGPT](#talk-to-chatgpt-)
-        - [Text transformation](#text-transformation-%EF%B8%8F)
-        - [Universal action & combined prompts](#universal-action--combined-prompts-%EF%B8%8F)
-        - [Aliases](#aliases-%EF%B8%8F)
-        - [Voice to ChatGPT](#voice-to-chatgpt-%EF%B8%8F)
-        - [Jailbreak](#jailbreak-)
-        - [ChatFred_ChatGPT.csv](#chatfred_chatgptcsv-)
-    - [Text generation with InstructGPT](#text-generation-with-instructgpt-)
-        - [Options](#options-)
-        - [Save conversations to file](#save-conversations-to-file-)
-    - [Image generation by DALL·E 2](#image-generation-by-dalle-2-%EF%B8%8F)
-- [Configure the workflow (optional)](#configure-the-workflow-optional-)
-- [Troubleshooting](#troubleshooting-%EF%B8%8F)
-- [Beta testing](#beta-testing-)
-- [Contributing](#contributing-)
-- [Safety best practices](#safety-best-practices-%EF%B8%8F)
+- [ChatFred](#chatfred)
+  - [Table of contents 📚](#table-of-contents-)
+  - [Setup 🧰](#setup-)
+  - [Usage 🧑‍💻](#usage-)
+    - [Talk to ChatGPT 💬](#talk-to-chatgpt-)
+      - [**Text transformation** ⚙️](#text-transformation-️)
+      - [**Universal action \& combined prompts** ➡️](#universal-action--combined-prompts-️)
+      - [**Aliases** ⌨️](#aliases-️)
+      - [**Voice to ChatGPT** 🗣️](#voice-to-chatgpt-️)
+      - [**Jailbreak** 🔓](#jailbreak-)
+      - [**`ChatFred_ChatGPT.csv`** 📄](#chatfred_chatgptcsv-)
+    - [Text generation with InstructGPT 🤖](#text-generation-with-instructgpt-)
+      - [**Options** 🤗](#options-)
+      - [**Save conversations to file** 📝](#save-conversations-to-file-)
+    - [Image generation by DALL·E 2 🖼️](#image-generation-by-dalle-2-️)
+  - [Configure the workflow (optional) 🦾](#configure-the-workflow-optional-)
+  - [Troubleshooting ⛑️](#troubleshooting-️)
+    - [General 🙀](#general-)
+    - [Remove history 🕰️](#remove-history-️)
+    - [Install Python 🐍](#install-python-)
+    - [Error messages 🚨](#error-messages-)
+    - [Open an issue 🕵️](#open-an-issue-️)
+  - [Beta testing 🧪](#beta-testing-)
+  - [Contributing 🤝](#contributing-)
+  - [Safety best practices 🛡️](#safety-best-practices-️)
 
 ## Setup 🧰
 [⤓ Install on the Alfred Gallery](https://alfred.app/workflows/chrislemke/chatfred/) or download it over [GitHub](https://github.com/chrislemke/ChatFred/releases) and add your OpenAI API key. If you have used ChatGPT or DALL·E 2, you already have an OpenAI account. Otherwise, you can [sign up here](https://beta.openai.com/signup) - You will receive [$5 in free credit](https://openai.com/api/pricing/), no payment data is required. Afterwards you can [create your API key](https://beta.openai.com/account/api-keys).
@@ -220,6 +227,7 @@ You can tweak the workflow to your liking. The following parameters are availabl
 - **Top-p**: Top-p sampling selects from the smallest possible set of words whose cumulative probability exceeds probability p. In this way, the number of words in the set can be dynamically increased and decreased according to the nearest word probability distribution. Default: `1`.
 - **Frequency penalty**: A value between `-2.0` and `2.0`. The frequency penalty parameter controls the model’s tendency to repeat predictions. Default: `0`.
 - **Presence penalty**: A Value between `-2.0` and `2.0`. The presence penalty parameter encourages the model to make novel predictions. Default: `0`.
+- **Custom API URL**: Custom OpenAI API Url. e.g. `https://closeai.deno.dev/v1`
 - **Always read out reply**: If enabled, ChatFred will read out all replies automatically. Default: `off`.
 - **Always save conversation to file**: If enabled, all your request and ChatFred's replies will automatically be saved to a file (`{File directory}/ChatFred.txt`). Only available for InstructGPT. Default: `off`.
 - **File directory**: Custom directory where the 'ChatFred.txt' should be stored. Default to the user's home directory (`~/`).

--- a/info.plist
+++ b/info.plist
@@ -4066,6 +4066,27 @@ Please refer to OpenAI's [safety best practices guide](https://platform.openai.c
 			<key>config</key>
 			<dict>
 				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>https://api.openai.com/v1</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Enter a custom OpenAI API URL address. If not entered, the default OpenAI API path will be used.</string>
+			<key>label</key>
+			<string>Custom OpenAI API URL</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>custom_api_url</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
 				<string>search</string>
 				<key>pairs</key>
 				<array>

--- a/workflow/src/image_generation.py
+++ b/workflow/src/image_generation.py
@@ -18,6 +18,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "libs"))
 import openai
 
 openai.api_key = os.getenv("api_key")
+if os.getenv("custom_api_url"):
+    openai.api_base = os.getenv("custom_api_url")
 __size = int(os.getenv("image_size") or 512)
 
 

--- a/workflow/src/text_chat.py
+++ b/workflow/src/text_chat.py
@@ -23,6 +23,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "libs"))
 import openai
 
 openai.api_key = os.getenv("api_key")
+if os.getenv("custom_api_url"):
+    openai.api_base = os.getenv("custom_api_url")
 
 __model = os.getenv("chat_gpt_model") or "gpt-3.5-turbo"
 __history_length = int(os.getenv("history_length") or 4)

--- a/workflow/src/text_completion.py
+++ b/workflow/src/text_completion.py
@@ -18,6 +18,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "libs"))
 import openai
 
 openai.api_key = os.getenv("api_key")
+if os.getenv("custom_api_url"):
+    openai.api_base = os.getenv("custom_api_url")
 __model = os.getenv("instruct_gpt_model") or "text-davinci-003"
 __temperature = float(os.getenv("temperature") or 0.0)
 __max_tokens = int(os.getenv("completion_max_tokens") or 50)


### PR DESCRIPTION
This allows users to use custom openAI API paths by setting the environment variable(config) `custom_api_url` to their custom API url address.

#51 