### PR TITLE
Remove python installation from troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,6 @@ When having trouble it is always a good idea to download the [newest release ver
 ### Remove history 🕰️
 Sometimes it makes sense to delete the history of your conversation with ChatGPT. Simply use the `forget me` command for this.
 
-### Install Python 🐍
-Also, make sure that you have some Python version installed. You can check this by running `python --version` in the terminal. If you don't have Python installed, you can download it as a [Homebrew package](https://brew.sh): `brew install python`.
-
 ### Error messages 🚨
 If you have received an error, you can ask ChatFred: `what does that even mean?` to get more information about it. If this prompt is too long for you - find some alternatives in the [`custom_prompts.py`](https://github.com/chrislemke/ChatFred/blob/main/workflow/src/custom_prompts.py) file.
 


### PR DESCRIPTION
The step to install Python is confusing people in the forum. They’re bumping into issues from OpenAI’s side (lack of clarity regarding the API key?) and thinking the problem is with the workflow.

There are a few problems with the instructions, namely that it asks people to run `python --version` when that would link to Python 2 and not Python 3. So it won’t produce a result from macOS Monterey 12.3 onward and on anything below that it would be wrong anyway because what the workflow uses is `python3`.

Furthermore, it is *not* necessary to install Python with Homebrew. As soon as you call `/usr/bin/python3` (or just `python3`) the first time, macOS will present the user with a GUI dialog asking them to install the Developer Tools. It takes two clicks (and waiting for a progress bar) and it’s done. From that point on, `/usr/bin/python3` will point to a real Python 3 runtime. People with Homebrew installed already have the Developer Tools, so it’ll just work.