### PR TITLE
1 Fix and 1 Optimization for the History Feature

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1562,7 +1562,7 @@ sys.stdout.write(sys.argv[2])</string>
 				<key>queuedelaymode</key>
 				<integer>0</integer>
 				<key>queuemode</key>
-				<integer>1</integer>
+				<integer>2</integer>
 				<key>runningsubtext</key>
 				<string>Loading...</string>
 				<key>script</key>

--- a/workflow/src/history_manager.py
+++ b/workflow/src/history_manager.py
@@ -33,12 +33,11 @@ def provide_history():
     prompt = get_query()
 
     if os.getenv("uuid_") is None or os.getenv("user_prompt") != prompt:
-
         # Return the result without history once first in case
         # the history or the prompt is too long
         # for the full history to generate
         # within a reasonable amount of time
-        
+
         # Lag is mostly caused by process.extract()
 
         # Utilized an Alfred feature that the variables'
@@ -48,10 +47,7 @@ def provide_history():
         uuid_ = str(uuid.uuid1())
 
         pre_history_dict = {
-            "variables": {
-                "user_prompt": prompt,
-                "uuid_": uuid_
-            },
+            "variables": {"user_prompt": prompt, "uuid_": uuid_},
             "rerun": 0.1,
             "items": [
                 {
@@ -60,9 +56,7 @@ def provide_history():
                     "subtitle": f"Talk to {__model} 💬".strip(),
                     "arg": [uuid_, prompt],
                     "autocomplete": prompt,
-                    "icon": {
-                        "path": "./icon.png"
-                    },
+                    "icon": {"path": "./icon.png"},
                 }
             ],
         }
@@ -92,7 +86,7 @@ def provide_history():
         0,
         (
             os.getenv("uuid_"),
-            prompt if prompt.strip() else '...',
+            prompt if prompt.strip() else "...",
             f"Talk to {__model} 💬",
             "0",
         ),
@@ -120,7 +114,7 @@ def provide_history():
     }
 
     stdout_write(json.dumps(response_dict))
-    
+
     return
 
 

--- a/workflow/src/history_manager.py
+++ b/workflow/src/history_manager.py
@@ -29,7 +29,48 @@ def stdout_write(output_string: str) -> None:
 
 def provide_history():
     """Provide the history of the user."""
+
     prompt = get_query()
+
+    if os.getenv("uuid_") is None or os.getenv("user_prompt") != prompt:
+
+        # Return the result without history once first in case
+        # the history or the prompt is too long
+        # for the full history to generate
+        # within a reasonable amount of time
+        
+        # Lag is mostly caused by process.extract()
+
+        # Utilized an Alfred feature that the variables'
+        # field will be passed back through to reruns of
+        # script from the same session
+        # Significantly increases speed for long prompts & long history
+        uuid_ = str(uuid.uuid1())
+
+        pre_history_dict = {
+            "variables": {
+                "user_prompt": prompt,
+                "uuid_": uuid_
+            },
+            "rerun": 0.1,
+            "items": [
+                {
+                    "type": "default",
+                    "title": prompt,
+                    "subtitle": f"Talk to {__model} 💬".strip(),
+                    "arg": [uuid_, prompt],
+                    "autocomplete": prompt,
+                    "icon": {
+                        "path": "./icon.png"
+                    },
+                }
+            ],
+        }
+
+        stdout_write(json.dumps(pre_history_dict))
+
+        return
+
     history: List[Tuple[str, str, str, str]] = []
 
     if not os.path.exists(__workflow_data_path):
@@ -45,13 +86,13 @@ def provide_history():
 
     history = list(reversed(history))
     if __history_type == "search" and prompt != "":
-        history = [tuple[0] for tuple in process.extract(prompt, history, limit=20)]
+        history = [tuple_[0] for tuple_ in process.extract(prompt, history, limit=20)]
 
     history.insert(
         0,
         (
-            str(uuid.uuid1()),
-            prompt if prompt.strip() else "...",
+            os.getenv("uuid_"),
+            prompt if prompt.strip() else '...',
             f"Talk to {__model} 💬",
             "0",
         ),
@@ -77,7 +118,10 @@ def provide_history():
             for index, entry in enumerate(history)
         ],
     }
-    sys.stdout.write(json.dumps(response_dict))
+
+    stdout_write(json.dumps(response_dict))
+    
+    return
 
 
 provide_history()

--- a/workflow/src/text_chat.py
+++ b/workflow/src/text_chat.py
@@ -159,7 +159,19 @@ def write_to_log(
             writer.writerow(
                 [str(uuid.uuid1()), jailbreak_prompt, "Okay! How can I help?", 1]
             )
-        writer.writerow([str(uuid.uuid1()), user_input, assistant_output, 0])
+
+        # A mulfunction of Alfred could lead to assistant_output being None but still logged
+        # leading to a line in the history being of a wrong length and when trying to read
+        # that line, history_manager.py fails at line: if row[3] == "0":
+        # so guarding is added here
+        writer.writerow(
+            [
+                str(uuid.uuid1()),
+                user_input if user_input else "",
+                assistant_output if assistant_output else "",
+                0,
+            ]
+        )
 
 
 def remove_log_file() -> None:


### PR DESCRIPTION
Fix: a rare case where abnormal quitting of Alfred window causes one history line to be of a wrong length, renders ChatFred unusable until that line is removed

Optimization: Lag due to `process.extract()` taking too long for a long history and a long prompt (which quickly becomes the case if you use LLM for sth like code explanation or translation) when history type set to "search" (default), the user should be able to use the original prompt as is while history is being fetched. 