### PR TITLE
fix: Can not set frequency_penalty and presence_penalty to -2 and 2

### DIFF
--- a/workflow/src/error_handler.py
+++ b/workflow/src/error_handler.py
@@ -42,7 +42,7 @@ def env_value_error_if_needed(
         return f"🚨 'Frequency penalty' must be between -2.0 and 2.0. But you have set it to {frequency_penalty}."
 
     if presence_penalty < -2.0 or presence_penalty > 2.0:
-        return f"🚨 'Presence penalty' must be between -2.0 and 2.0. But you have set it to {frequency_penalty}."
+        return f"🚨 'Presence penalty' must be between -2.0 and 2.0. But you have set it to {presence_penalty}."
 
     return None
 

--- a/workflow/src/error_handler.py
+++ b/workflow/src/error_handler.py
@@ -38,11 +38,11 @@ def env_value_error_if_needed(
     ):
         return "🚨 'Maximum tokens' must be ≤ 2048."
 
-    if frequency_penalty <= -2.0 or frequency_penalty >= 2.0:
-        return "🚨 'Frequency penalty' must be between -2.0 and 2.0."
+    if frequency_penalty < -2.0 or frequency_penalty > 2.0:
+        return f"🚨 'Frequency penalty' must be between -2.0 and 2.0. But you have set it to {frequency_penalty}."
 
-    if presence_penalty <= -2.0 or presence_penalty >= 2.0:
-        return "🚨 'Presence penalty' must be between -2.0 and 2.0."
+    if presence_penalty < -2.0 or presence_penalty > 2.0:
+        return f"🚨 'Presence penalty' must be between -2.0 and 2.0. But you have set it to {frequency_penalty}."
 
     return None
 

--- a/workflow/src/libs/prompt_toolkit/application/application.py
+++ b/workflow/src/libs/prompt_toolkit/application/application.py
@@ -1020,7 +1020,6 @@ class Application(Generic[_AppResult]):
         """
         app = self
         # Inline import on purpose. We don't want to import pdb, if not needed.
-        import pdb
         from types import FrameType
 
         TraceDispatch = Callable[[FrameType, str, Any], Any]
@@ -1077,7 +1076,7 @@ class Application(Generic[_AppResult]):
             finally:
                 done.set()
 
-        class CustomPdb(pdb.Pdb):
+        class CustomPdb():
             def trace_dispatch(
                 self, frame: FrameType, event: str, arg: Any
             ) -> TraceDispatch:

--- a/workflow/src/text_chat.py
+++ b/workflow/src/text_chat.py
@@ -167,8 +167,8 @@ def write_to_log(
         writer.writerow(
             [
                 str(uuid.uuid1()),
-                user_input if user_input else "",
-                assistant_output if assistant_output else "",
+                user_input if user_input else "...",
+                assistant_output if assistant_output else "...",
                 0,
             ]
         )

--- a/workflow/src/text_chat.py
+++ b/workflow/src/text_chat.py
@@ -319,13 +319,11 @@ def make_chat_request(
                     os.path.dirname(__file__), "fonts", "Helvetica.ttc"
                 )
             }
-            theme = ft.Theme
+            page.theme = ft.Theme(font_family="Helvetica")
 
-            page.theme = theme(font_family="Helvetica")
-
-            # press Esc to close window
+            # press Esc or cmd + w to close window
             def on_keyboard(e: ft.KeyboardEvent):
-                if e.key == "Escape":
+                if e.key == "Escape" or (e.key == "W" and e.meta):
                     page.window_destroy()
 
             page.on_keyboard_event = on_keyboard
@@ -346,7 +344,7 @@ def make_chat_request(
                 chunk_message = chunk["choices"][0]["delta"]
                 collected_messages.append(chunk_message)
 
-                # contact streamed result and add a left half block for ChatGPT-like cursor effect
+                # concatenate streamed result and add a left half block for ChatGPT-like cursor effect
                 t.value = (
                     f"{''.join([m.get('content', '') for m in collected_messages])}▌"
                 )
@@ -355,7 +353,7 @@ def make_chat_request(
             # remove left half block since all results have been streamed
             t.value = t.value[:-1]
             # set cursor focus to TextField
-            t.autofocus = True
+            t.focus()
             t.update()
 
             # all content is loaded, the user should be able to scrolling freely

--- a/workflow/src/text_chat.py
+++ b/workflow/src/text_chat.py
@@ -289,7 +289,7 @@ def make_chat_request(
             stream=bool(stream_reply),
         )
     except Exception as exception:  # pylint: disable=broad-except
-        response = exception_response(exception)
+        response_mes = exception_response(exception)
         write_to_cache("last_chat_request_successful", False)
         log_error_if_needed(
             model=__model,
@@ -303,6 +303,7 @@ def make_chat_request(
                 "presence_penalty": presence_penalty,
             },
         )
+        return prompt, response_mes
     if __stream_reply:
         collected_messages = []
 


### PR DESCRIPTION
Fix: You can set frequency_penalty and presence_penalty to -2 and 2 now. 

Fix: The workflow will not continue to show a Flet window if an error occurs. 

Fix: auto focus on streamed result not working

Fix: former fix guarding assistant_output should use sth other than an empty string.

Feature: cmd+w to close Flet window