### PR TITLE
Implemented support for more LLM models

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -4584,6 +4584,106 @@ Please refer to OpenAI's [safety best practices guide](https://platform.openai.c
 			<key>variable</key>
 			<string>stream_reply</string>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Alternative API key used for chat completions only, overrides the default one if set. E.g. one from openrouter.ai</string>
+			<key>label</key>
+			<string>Alternative API key</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>alternative_key</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>openai/gpt-4</string>
+				<key>pairs</key>
+				<array>
+					<array>
+						<string>OpenAI: GPT-4</string>
+						<string>openai/gpt-4</string>
+					</array>
+					<array>
+						<string>OpenAI: GPT-4 32k</string>
+						<string>openai/gpt-4-32k</string>
+					</array>
+					<array>
+						<string>Google: PaLM 2 Bison (Code Chat)</string>
+						<string>google/palm-2-codechat-bison</string>
+					</array>
+					<array>
+						<string>Google: PaLM 2 Bison</string>
+						<string>google/palm-2-chat-bison</string>
+					</array>
+					<array>
+						<string>OpenAI: GPT-3.5 Turbo</string>
+						<string>openai/gpt-3.5-turbo</string>
+					</array>
+					<array>
+						<string>OpenAI: GPT-3.5 Turbo 16k</string>
+						<string>openai/gpt-3.5-turbo-16k</string>
+					</array>
+					<array>
+						<string>Anthropic: Claude v2</string>
+						<string>anthropic/claude-2</string>
+					</array>
+					<array>
+						<string>Anthropic: Claude Instant v1</string>
+						<string>anthropic/claude-instant-v1</string>
+					</array>
+					<array>
+						<string>Meta: Llama v2 13B Chat (beta)</string>
+						<string>meta-llama/llama-2-13b-chat</string>
+					</array>
+					<array>
+						<string>Meta: Llama v2 70B Chat (beta)</string>
+						<string>meta-llama/llama-2-70b-chat</string>
+					</array>
+				</array>
+			</dict>
+			<key>description</key>
+			<string>LLM model choices for chat completion when `Alternative key` is set. Compatible with openrouter.ai</string>
+			<key>label</key>
+			<string>Alternative model</string>
+			<key>type</key>
+			<string>popupbutton</string>
+			<key>variable</key>
+			<string>alternative_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>Something like {"HTTP-Referer": "http://alfred.app", "X-Title": "Alfred"}</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Custom header field send with the request for chat completions. Required by openrouter.ai</string>
+			<key>label</key>
+			<string>Custom headers</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>custom_headers</string>
+		</dict>
 	</array>
 	<key>version</key>
 	<string>1.6.1</string>

--- a/workflow/src/history_manager.py
+++ b/workflow/src/history_manager.py
@@ -14,7 +14,11 @@ from thefuzz import process
 __workflow_data_path = os.getenv("alfred_workflow_data") or os.path.expanduser("~")
 __log_file_path = f"{__workflow_data_path}/ChatFred_ChatGPT.csv"
 __history_type = os.getenv("history_type")
-__model = os.getenv("chat_gpt_model") or "gpt-3.5-turbo"
+
+if os.getenv("alternative_key"):
+    __model = os.getenv("alternative_model")
+else:
+    __model = os.getenv("chat_gpt_model") or "gpt-3.5-turbo"
 
 
 def get_query() -> str:


### PR DESCRIPTION
This PR implements support for more LLM models like Claude 2 from Anthropic, PaLM from Google, Llama v2 70B from Meta, and GPT-4 from OpenAI (more models are being added) by routing the request using [OpenRouter](https://openrouter.ai/docs) with change of code and affected compatibility kept to a minimum.

1) Requests to OpenRouter use the same `openai` module as those sent to OpenAI, no additional dependency is required. The only difference is that it requires a `headers` argument for tracking usages from different apps. User can fill out whatever header they like for potentially supporting more routing services. 

2) The option to use OpenRouter (or other services supported) is opt-in, means that users who doesn't know or don't want to use it won't feel a thing after they upgrade the workflow. And if they do use it, it will only apply to the chat completion part, instruct GPT part and image generation part will still use models from OpenAI. 

3) Unsupported parameter will be ignored for models that do not support it, such as `stream` for `meta-llama/llama-2-70b-chat`, in which case a window will show after the full reply is returned. No code modification for each parameter based on each model.